### PR TITLE
Test enhancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.phar
 composer.lock
 vendor
 .idea
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ matrix:
     env: setup=lowest
   - php: '7.3'
     env: coverage=true
-  - php: 7.4snapshot
+  - php: '7.4'
     env: setup=lowest
-  - php: 7.4snapshot
+  - php: '7.4'
 
 before_install:
 - travis_retry composer self-update


### PR DESCRIPTION
# Changed log
- The `.phpunit.result.cache` is cached `PHPUnit` result.
It should not be under Git version control and add this in `.gitignore` file.
- The `php-7.4` is available on Travis CI build environment and using `php-7.4` instead.
- The `"minimum-stability": "dev"` setting is defined on `composer.json` file and it will install unstable dependencies during `composer install` work.
To install the stable dependencies, adding the `"prefer-stable": true` to resolve this problem.